### PR TITLE
1.x dev

### DIFF
--- a/FluentValidationLister.Filter/FluentValidationLister.Filter.csproj
+++ b/FluentValidationLister.Filter/FluentValidationLister.Filter.csproj
@@ -12,11 +12,10 @@
     <PropertyGroup>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <PackageLicenseFile></PackageLicenseFile>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageReleaseNotes>- Removed dependency on FluentValidation.AspNetCore. 
-- Fixed camel-case issues with ASP.NET 3.x.</PackageReleaseNotes>
+        <PackageReleaseNotes>- Added a null check for the ContentType header in the action filter. Now defaults to JSON if nothing is specified.</PackageReleaseNotes>
         <RepositoryType>git</RepositoryType>
         <Copyright>Copyright (c) Dan Ware 2019</Copyright>
         <PackageProjectUrl>https://github.com/scandal-uk/fluentvalidationlister</PackageProjectUrl>

--- a/FluentValidationLister.Filter/ValidationActionFilter.cs
+++ b/FluentValidationLister.Filter/ValidationActionFilter.cs
@@ -40,7 +40,11 @@
                 .MakeGenericType(GetModelType(model))) as IValidator;
 
             // todo: Determine if user has chosen Pascal case! Tricky as its different between ASPNETCore 2 & 3
-            bool useJson = context.HttpContext.Request.ContentType.ToLowerInvariant().Contains("json");
+            bool useJson = true;
+            if (context.HttpContext.Request.ContentType != null)
+            {
+                useJson = context.HttpContext.Request.ContentType.ToLowerInvariant().Contains("json");
+            }
 
             // Return validation rules if requested
             if (context.HttpContext.Request.Query.Keys.Any(val => val == "validation"))


### PR DESCRIPTION
In some cases the ContentType header could be missing. In these cases we will default to JSON.